### PR TITLE
Add controller route inlay hints

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 *.log
 *.debug
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772963539,
+        "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  outputs = {nixpkgs, ...}: let
+    systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+    forAllSystems = nixpkgs.lib.genAttrs systems;
+    nixpkgsFor = forAllSystems (system:
+      import nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+      });
+  in {
+    devShells = forAllSystems (system: let
+      pkgs = nixpkgsFor.${system};
+    in {
+      default = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          go_1_24
+          gnumake
+        ];
+        nativeBuildInputs = [];
+      };
+    });
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
         buildInputs = with pkgs; [
           go_1_24
           gnumake
+          gopls
         ];
         nativeBuildInputs = [];
       };

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.4
 
 require (
 	github.com/EmranMR/tree-sitter-blade v0.11.1-0.20241209120652-47baa7ba1f9d
-	github.com/laravel-ls/protocol v0.1.0
+	github.com/laravel-ls/protocol v0.1.1
 	github.com/laravel-ls/uri v0.0.1
 	github.com/pnx/tree-sitter-dotenv v0.0.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,12 @@ github.com/laravel-ls/protocol v0.0.0-20260301220821-3094133c242e h1:KC/W5bIthGT
 github.com/laravel-ls/protocol v0.0.0-20260301220821-3094133c242e/go.mod h1:d9vs9ABGd8/5GSxX5VDRRyXOPKYzNWpalwV/Z/vdSf0=
 github.com/laravel-ls/protocol v0.1.0 h1:IPgpENJatfaGiCcfm/08f3A88tN1wRbKlCFcEJI5UV8=
 github.com/laravel-ls/protocol v0.1.0/go.mod h1:d9vs9ABGd8/5GSxX5VDRRyXOPKYzNWpalwV/Z/vdSf0=
+github.com/laravel-ls/protocol v0.1.1-0.20260319114216-7cebe3d8180f h1:9+4YisTmfGxua5zKwbgbEly5soGJjcr99fcSlFCQIzo=
+github.com/laravel-ls/protocol v0.1.1-0.20260319114216-7cebe3d8180f/go.mod h1:d9vs9ABGd8/5GSxX5VDRRyXOPKYzNWpalwV/Z/vdSf0=
+github.com/laravel-ls/protocol v0.1.1-0.20260319132305-5fe36eb7d676 h1:QrdNIkroXbesZ+xmZRDasTZztnHV+BLbGl18FCKMYjA=
+github.com/laravel-ls/protocol v0.1.1-0.20260319132305-5fe36eb7d676/go.mod h1:d9vs9ABGd8/5GSxX5VDRRyXOPKYzNWpalwV/Z/vdSf0=
+github.com/laravel-ls/protocol v0.1.1 h1:dG0QRL4pYLtcFi+axEuVW49GzYj1UINMesBrh/fnO+0=
+github.com/laravel-ls/protocol v0.1.1/go.mod h1:d9vs9ABGd8/5GSxX5VDRRyXOPKYzNWpalwV/Z/vdSf0=
 github.com/laravel-ls/uri v0.0.1 h1:L8TcV6s4o92cmVQnkf8Cz0xd731xcIUFZvcd2o3W7Pc=
 github.com/laravel-ls/uri v0.0.1/go.mod h1:SJUHGrMb7GZNf0EZ1btQTaAlHYe/fOwHNZp2ovc+h00=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=

--- a/laravel/providers/route/inlay_hints.go
+++ b/laravel/providers/route/inlay_hints.go
@@ -66,7 +66,7 @@ func parseControllerInfo(file *parser.File) *controllerInfo {
 }
 
 func (p *Provider) ResolveInlayHints(ctx provider.InlayHintContext) {
-	repo, err := p.routes(ctx.BaseContext)
+	repo, err := p.routes()
 	if err != nil {
 		return
 	}
@@ -76,9 +76,13 @@ func (p *Provider) ResolveInlayHints(ctx provider.InlayHintContext) {
 		return
 	}
 
+	fqnParts := strings.Split(info.FQN, "\\")
+	classBaseName := fqnParts[len(fqnParts)-1]
+
 	for _, route := range repo {
 		parts := strings.SplitN(route.Action, "@", 2)
-		if parts[0] != info.FQN && !strings.HasSuffix(info.FQN, "\\"+parts[0]) {
+		// Match by full FQN (e.g. "App\Http\Controllers\HomeController") or by unqualified class name (e.g. "HomeController").
+		if parts[0] != info.FQN && parts[0] != classBaseName {
 			continue
 		}
 

--- a/laravel/providers/route/inlay_hints.go
+++ b/laravel/providers/route/inlay_hints.go
@@ -13,7 +13,30 @@ import (
 
 type controllerInfo struct {
 	FQN     string              // e.g. "App\Http\Controllers\HomeController"
-	Methods map[string]ts.Point // method name -> start position
+	Methods map[string]ts.Point // method name -> end-of-signature-line position
+}
+
+// lineEndColumn returns the byte column of the end of the given zero-indexed
+// row in src (i.e. the number of bytes before the newline, or end of file).
+func lineEndColumn(src []byte, row uint) uint {
+	var currentRow uint
+	lineStart := 0
+	for i, b := range src {
+		if currentRow == row {
+			if b == '\n' {
+				return uint(i - lineStart)
+			}
+		} else if b == '\n' {
+			currentRow++
+			if currentRow == row {
+				lineStart = i + 1
+			}
+		}
+	}
+	if currentRow == row {
+		return uint(len(src) - lineStart)
+	}
+	return 0
 }
 
 func parseControllerInfo(file *parser.File) *controllerInfo {
@@ -44,7 +67,11 @@ func parseControllerInfo(file *parser.File) *controllerInfo {
 					continue
 				}
 				if methodName := treesitter.NamedChildOfKind(member, "name"); methodName != nil {
-					methods[methodName.Utf8Text(file.Src)] = member.StartPosition()
+					startRow := member.StartPosition().Row
+					methods[methodName.Utf8Text(file.Src)] = ts.Point{
+						Row:    startRow,
+						Column: lineEndColumn(file.Src, startRow),
+					}
 				}
 			}
 		}

--- a/laravel/providers/route/inlay_hints.go
+++ b/laravel/providers/route/inlay_hints.go
@@ -1,0 +1,100 @@
+package route
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/laravel-ls/laravel-ls/parser"
+	"github.com/laravel-ls/laravel-ls/provider"
+	"github.com/laravel-ls/laravel-ls/treesitter"
+
+	ts "github.com/tree-sitter/go-tree-sitter"
+)
+
+type controllerInfo struct {
+	FQN     string              // e.g. "App\Http\Controllers\HomeController"
+	Methods map[string]ts.Point // method name -> start position
+}
+
+func parseControllerInfo(file *parser.File) *controllerInfo {
+	root := file.Tree.Root()
+
+	var namespace string
+	var className string
+	methods := map[string]ts.Point{}
+
+	for i := uint(0); i < root.NamedChildCount(); i++ {
+		child := root.NamedChild(i)
+		switch child.Kind() {
+		case "namespace_definition":
+			if nameNode := treesitter.NamedChildOfKind(child, "namespace_name"); nameNode != nil {
+				namespace = nameNode.Utf8Text(file.Src)
+			}
+		case "class_declaration":
+			if nameNode := treesitter.NamedChildOfKind(child, "name"); nameNode != nil {
+				className = nameNode.Utf8Text(file.Src)
+			}
+			body := treesitter.NamedChildOfKind(child, "declaration_list")
+			if body == nil {
+				continue
+			}
+			for j := uint(0); j < body.NamedChildCount(); j++ {
+				member := body.NamedChild(j)
+				if member.Kind() != "method_declaration" {
+					continue
+				}
+				if methodName := treesitter.NamedChildOfKind(member, "name"); methodName != nil {
+					methods[methodName.Utf8Text(file.Src)] = member.StartPosition()
+				}
+			}
+		}
+	}
+
+	if className == "" {
+		return nil
+	}
+
+	fqn := className
+	if namespace != "" {
+		fqn = namespace + "\\" + className
+	}
+
+	return &controllerInfo{
+		FQN:     fqn,
+		Methods: methods,
+	}
+}
+
+func (p *Provider) ResolveInlayHints(ctx provider.InlayHintContext) {
+	repo, err := p.routes(ctx.BaseContext)
+	if err != nil {
+		return
+	}
+
+	info := parseControllerInfo(ctx.File)
+	if info == nil {
+		return
+	}
+
+	for _, route := range repo {
+		parts := strings.SplitN(route.Action, "@", 2)
+		if parts[0] != info.FQN && !strings.HasSuffix(info.FQN, "\\"+parts[0]) {
+			continue
+		}
+
+		methodName := "__invoke"
+		if len(parts) == 2 {
+			methodName = parts[1]
+		}
+
+		pos, ok := info.Methods[methodName]
+		if !ok {
+			continue
+		}
+
+		ctx.Publish(provider.InlayHint{
+			Position: pos,
+			Label:    fmt.Sprintf("[%s /%s]", route.Method, strings.TrimPrefix(route.URI, "/")),
+		})
+	}
+}

--- a/laravel/providers/route/inlay_hints.go
+++ b/laravel/providers/route/inlay_hints.go
@@ -92,11 +92,9 @@ func (p *Provider) ResolveInlayHints(ctx provider.InlayHintContext) {
 			continue
 		}
 
-		label := fmt.Sprintf("[%s /%s]", route.Method, strings.TrimPrefix(route.URI, "/"))
-		ctx.Logger.WithField("label", label).WithField("method", methodName).Debug("inlay hints: publishing hint")
 		ctx.Publish(provider.InlayHint{
 			Position: pos,
-			Label:    label,
+			Label:    fmt.Sprintf("[%s /%s]", route.Method, strings.TrimPrefix(route.URI, "/")),
 		})
 	}
 }

--- a/laravel/providers/route/inlay_hints.go
+++ b/laravel/providers/route/inlay_hints.go
@@ -68,6 +68,7 @@ func parseControllerInfo(file *parser.File) *controllerInfo {
 func (p *Provider) ResolveInlayHints(ctx provider.InlayHintContext) {
 	repo, err := p.routes()
 	if err != nil {
+		ctx.Logger.WithError(err).Warn("inlay hints: failed to get routes")
 		return
 	}
 

--- a/laravel/providers/route/inlay_hints.go
+++ b/laravel/providers/route/inlay_hints.go
@@ -92,9 +92,11 @@ func (p *Provider) ResolveInlayHints(ctx provider.InlayHintContext) {
 			continue
 		}
 
+		label := fmt.Sprintf("[%s /%s]", route.Method, strings.TrimPrefix(route.URI, "/"))
+		ctx.Logger.WithField("label", label).WithField("method", methodName).Debug("inlay hints: publishing hint")
 		ctx.Publish(provider.InlayHint{
 			Position: pos,
-			Label:    fmt.Sprintf("[%s /%s]", route.Method, strings.TrimPrefix(route.URI, "/")),
+			Label:    label,
 		})
 	}
 }

--- a/laravel/providers/route/inlay_hints_test.go
+++ b/laravel/providers/route/inlay_hints_test.go
@@ -157,8 +157,6 @@ class HomeController
 	})
 
 	t.Run("class name that is a suffix of another does not match", func(t *testing.T) {
-		// "Controller" must not match a class named "HomeController" — this was
-		// the false-positive risk with the old HasSuffix approach.
 		p := providerWithRoutes(repository.RouteEntry{
 			Method: "GET", URI: "/", Action: `Controller@index`,
 		})

--- a/laravel/providers/route/inlay_hints_test.go
+++ b/laravel/providers/route/inlay_hints_test.go
@@ -11,6 +11,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestLineEndColumn(t *testing.T) {
+	tests := []struct {
+		name   string
+		src    string
+		row    uint
+		expect uint
+	}{
+		{"first line", "hello\nworld", 0, 5},
+		{"second line", "hello\nworld", 1, 5},
+		{"blank line", "foo\n\nbar", 1, 0},
+		{"last line no newline", "abc", 0, 3},
+		{"row beyond content", "abc\n", 1, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := lineEndColumn([]byte(tt.src), tt.row)
+			require.Equal(t, tt.expect, got)
+		})
+	}
+}
+
 func mustParsePHP(t *testing.T, src string) *parser.File {
 	t.Helper()
 	f, err := parser.Parse([]byte(src), file.TypePHP)

--- a/laravel/providers/route/inlay_hints_test.go
+++ b/laravel/providers/route/inlay_hints_test.go
@@ -5,6 +5,9 @@ import (
 
 	"github.com/laravel-ls/laravel-ls/file"
 	"github.com/laravel-ls/laravel-ls/parser"
+	"github.com/laravel-ls/laravel-ls/provider"
+	"github.com/laravel-ls/laravel-ls/utils/repository"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -89,4 +92,141 @@ class ShowDashboard
 			require.Len(t, info.Methods, len(tt.methods))
 		})
 	}
+}
+
+func resolveHints(t *testing.T, p *Provider, src string) []provider.InlayHint {
+	t.Helper()
+	f := mustParsePHP(t, src)
+	var hints []provider.InlayHint
+	p.ResolveInlayHints(provider.InlayHintContext{
+		BaseContext: provider.BaseContext{
+			Logger: log.WithField("test", t.Name()),
+			File:   f,
+		},
+		Publish: func(h provider.InlayHint) {
+			hints = append(hints, h)
+		},
+	})
+	return hints
+}
+
+func providerWithRoutes(routes ...repository.RouteEntry) *Provider {
+	p := &Provider{}
+	repo := make(repository.RouteRepository)
+	for i, r := range routes {
+		repo[string(rune('a'+i))] = r
+	}
+	p.routeCache = repo
+	return p
+}
+
+func TestResolveInlayHints(t *testing.T) {
+	const namespacedController = `<?php
+namespace App\Http\Controllers;
+
+class HomeController
+{
+    public function index() {}
+    public function show() {}
+}`
+
+	t.Run("fully qualified action matches controller FQN", func(t *testing.T) {
+		p := providerWithRoutes(repository.RouteEntry{
+			Method: "GET", URI: "/", Action: `App\Http\Controllers\HomeController@index`,
+		})
+		hints := resolveHints(t, p, namespacedController)
+		require.Len(t, hints, 1)
+		require.Equal(t, "[GET /]", hints[0].Label)
+	})
+
+	t.Run("unqualified class name matches by base name", func(t *testing.T) {
+		p := providerWithRoutes(repository.RouteEntry{
+			Method: "POST", URI: "home", Action: `HomeController@index`,
+		})
+		hints := resolveHints(t, p, namespacedController)
+		require.Len(t, hints, 1)
+		require.Equal(t, "[POST /home]", hints[0].Label)
+	})
+
+	t.Run("wrong class name does not match", func(t *testing.T) {
+		p := providerWithRoutes(repository.RouteEntry{
+			Method: "GET", URI: "/", Action: `OtherController@index`,
+		})
+		hints := resolveHints(t, p, namespacedController)
+		require.Empty(t, hints)
+	})
+
+	t.Run("class name that is a suffix of another does not match", func(t *testing.T) {
+		// "Controller" must not match a class named "HomeController" — this was
+		// the false-positive risk with the old HasSuffix approach.
+		p := providerWithRoutes(repository.RouteEntry{
+			Method: "GET", URI: "/", Action: `Controller@index`,
+		})
+		hints := resolveHints(t, p, namespacedController)
+		require.Empty(t, hints)
+	})
+
+	t.Run("invokable controller with no @ in action", func(t *testing.T) {
+		src := `<?php
+namespace App\Http\Controllers;
+
+class ShowDashboard
+{
+    public function __invoke() {}
+}`
+		p := providerWithRoutes(repository.RouteEntry{
+			Method: "GET", URI: "dashboard", Action: `App\Http\Controllers\ShowDashboard`,
+		})
+		hints := resolveHints(t, p, src)
+		require.Len(t, hints, 1)
+		require.Equal(t, "[GET /dashboard]", hints[0].Label)
+	})
+
+	t.Run("method not found in controller produces no hint", func(t *testing.T) {
+		p := providerWithRoutes(repository.RouteEntry{
+			Method: "GET", URI: "/", Action: `HomeController@missing`,
+		})
+		hints := resolveHints(t, p, namespacedController)
+		require.Empty(t, hints)
+	})
+
+	t.Run("multiple routes produce multiple hints", func(t *testing.T) {
+		p := providerWithRoutes(
+			repository.RouteEntry{Method: "GET", URI: "/", Action: `HomeController@index`},
+			repository.RouteEntry{Method: "GET", URI: "home/{id}", Action: `HomeController@show`},
+		)
+		hints := resolveHints(t, p, namespacedController)
+		require.Len(t, hints, 2)
+		labels := []string{hints[0].Label, hints[1].Label}
+		require.ElementsMatch(t, []string{"[GET /]", "[GET /home/{id}]"}, labels)
+	})
+
+	t.Run("non-class PHP file produces no hints", func(t *testing.T) {
+		p := providerWithRoutes(repository.RouteEntry{
+			Method: "GET", URI: "/", Action: `HomeController@index`,
+		})
+		hints := resolveHints(t, p, `<?php echo "hello";`)
+		require.Empty(t, hints)
+	})
+
+	t.Run("no routes produces no hints", func(t *testing.T) {
+		p := &Provider{}
+		p.routeCache = make(repository.RouteRepository)
+		hints := resolveHints(t, p, namespacedController)
+		require.Empty(t, hints)
+	})
+}
+
+func TestOnFileSaved(t *testing.T) {
+	t.Run("file outside routes dir returns nil", func(t *testing.T) {
+		p := &Provider{rootPath: "/app"}
+		ch := p.OnFileSaved("/app/app/Http/Controllers/HomeController.php")
+		require.Nil(t, ch)
+	})
+
+	t.Run("nil project returns nil", func(t *testing.T) {
+		p := &Provider{rootPath: "/app", project: nil}
+		ch := p.OnFileSaved("/app/routes/web.php")
+		require.Nil(t, ch)
+	})
 }

--- a/laravel/providers/route/inlay_hints_test.go
+++ b/laravel/providers/route/inlay_hints_test.go
@@ -1,0 +1,92 @@
+package route
+
+import (
+	"testing"
+
+	"github.com/laravel-ls/laravel-ls/file"
+	"github.com/laravel-ls/laravel-ls/parser"
+	"github.com/stretchr/testify/require"
+)
+
+func mustParsePHP(t *testing.T, src string) *parser.File {
+	t.Helper()
+	f, err := parser.Parse([]byte(src), file.TypePHP)
+	require.NoError(t, err)
+	return f
+}
+
+func TestParseControllerInfo(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		expectNil bool
+		fqn       string
+		methods   []string
+	}{
+		{
+			name: "controller with namespace",
+			src: `<?php
+namespace App\Http\Controllers;
+
+class HomeController
+{
+    public function index() {}
+    public function show() {}
+}`,
+			fqn:     `App\Http\Controllers\HomeController`,
+			methods: []string{"index", "show"},
+		},
+		{
+			name: "controller without namespace",
+			src: `<?php
+class UserController
+{
+    public function index() {}
+}`,
+			fqn:     "UserController",
+			methods: []string{"index"},
+		},
+		{
+			name: "invokable controller",
+			src: `<?php
+namespace App\Http\Controllers;
+
+class ShowDashboard
+{
+    public function __invoke() {}
+}`,
+			fqn:     `App\Http\Controllers\ShowDashboard`,
+			methods: []string{"__invoke"},
+		},
+		{
+			name:      "non-class PHP file",
+			src:       `<?php echo "hello";`,
+			expectNil: true,
+		},
+		{
+			name:      "route file with closures",
+			src:       `<?php use Illuminate\Support\Facades\Route; Route::get('/', function () { return view('welcome'); });`,
+			expectNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := mustParsePHP(t, tt.src)
+			info := parseControllerInfo(f)
+
+			if tt.expectNil {
+				require.Nil(t, info)
+				return
+			}
+
+			require.NotNil(t, info)
+			require.Equal(t, tt.fqn, info.FQN)
+			for _, method := range tt.methods {
+				_, ok := info.Methods[method]
+				require.True(t, ok, "expected method %q in controller %q", method, tt.fqn)
+			}
+			require.Len(t, info.Methods, len(tt.methods))
+		})
+	}
+}

--- a/laravel/providers/route/provider.go
+++ b/laravel/providers/route/provider.go
@@ -5,7 +5,6 @@ import (
 	"path"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/laravel-ls/laravel-ls/file"
 	"github.com/laravel-ls/laravel-ls/laravel/providers/route/queries"
@@ -17,16 +16,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const routeCacheTTL = 30 * time.Second
-
 type Provider struct {
 	rootPath string
 	project  *project.Project
 
-	mu             sync.Mutex
-	routeCache     repository.RouteRepository
-	routeCacheTime time.Time
-	routeGen       uint64 // incremented on invalidation; prevents stale PHP results from overwriting a cleared cache
+	mu         sync.Mutex
+	routeCache repository.RouteRepository
+	routeGen   uint64 // incremented on invalidation; prevents stale PHP results from overwriting a cleared cache
 }
 
 func NewProvider() *Provider {
@@ -64,21 +60,21 @@ func (p *Provider) OnFileSaved(filename string) <-chan struct{} {
 		if p.routeGen == gen {
 			log.WithField("routes", len(repo)).WithField("gen", gen).Debug("routes: pre-warm complete, storing in cache")
 			p.routeCache = repo
-			p.routeCacheTime = time.Now()
 		}
 		p.mu.Unlock()
 	}()
 	return done
 }
 
-// routes returns the route repository, using a short-lived cache to avoid
-// spawning a PHP process on every inlay hint refresh.
+// routes returns the route repository, cached in memory and invalidated on
+// routes file save. The first call after startup or invalidation spawns a
+// PHP process to load the routes; subsequent calls return the cached result.
 func (p *Provider) routes(ctx provider.BaseContext) (repository.RouteRepository, error) {
 	p.mu.Lock()
-	cache, cacheTime, gen := p.routeCache, p.routeCacheTime, p.routeGen
+	cache, gen := p.routeCache, p.routeGen
 	p.mu.Unlock()
 
-	if cache != nil && time.Since(cacheTime) < routeCacheTTL {
+	if cache != nil {
 		return cache, nil
 	}
 
@@ -92,7 +88,6 @@ func (p *Provider) routes(ctx provider.BaseContext) (repository.RouteRepository,
 	if p.routeGen == gen {
 		log.WithField("routes", len(repo)).WithField("gen", gen).Debug("routes: PHP call complete, storing in cache")
 		p.routeCache = repo
-		p.routeCacheTime = time.Now()
 	} else {
 		log.WithField("gen_expected", gen).WithField("gen_current", p.routeGen).Debug("routes: PHP result discarded (invalidated during call)")
 	}

--- a/laravel/providers/route/provider.go
+++ b/laravel/providers/route/provider.go
@@ -3,6 +3,7 @@ package route
 import (
 	"fmt"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
@@ -12,27 +13,64 @@ import (
 	"github.com/laravel-ls/laravel-ls/treesitter/php"
 	"github.com/laravel-ls/laravel-ls/utils/repository"
 	"github.com/laravel-ls/protocol"
+	log "github.com/sirupsen/logrus"
 )
 
 const routeCacheTTL = 30 * time.Second
 
 type Provider struct {
 	rootPath string
+	project  interface{ Routes() (repository.RouteRepository, error) }
 
 	mu             sync.Mutex
 	routeCache     repository.RouteRepository
 	routeCacheTime time.Time
+	routeGen       uint64 // incremented on invalidation; prevents stale PHP results from overwriting a cleared cache
 }
 
 func NewProvider() *Provider {
 	return &Provider{}
 }
 
+// OnFileSaved invalidates the route cache when a file under routes/ is saved.
+// Returns a channel that closes when the cache has been re-warmed via a fresh
+// PHP call, or nil if the file was not in the routes directory.
+func (p *Provider) OnFileSaved(filename string) <-chan struct{} {
+	routesDir := path.Join(p.rootPath, "routes") + "/"
+	if !strings.HasPrefix(filename, routesDir) {
+		return nil
+	}
+
+	p.mu.Lock()
+	p.routeCache = nil
+	p.routeGen++
+	gen := p.routeGen
+	p.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		repo, err := p.project.Routes()
+		if err != nil {
+			log.WithError(err).Debug("routes: OnFileSaved pre-warm failed")
+			return
+		}
+		p.mu.Lock()
+		if p.routeGen == gen {
+			log.WithField("routes", len(repo)).WithField("gen", gen).Debug("routes: pre-warm complete, storing in cache")
+			p.routeCache = repo
+			p.routeCacheTime = time.Now()
+		}
+		p.mu.Unlock()
+	}()
+	return done
+}
+
 // routes returns the route repository, using a short-lived cache to avoid
 // spawning a PHP process on every inlay hint refresh.
 func (p *Provider) routes(ctx provider.BaseContext) (repository.RouteRepository, error) {
 	p.mu.Lock()
-	cache, cacheTime := p.routeCache, p.routeCacheTime
+	cache, cacheTime, gen := p.routeCache, p.routeCacheTime, p.routeGen
 	p.mu.Unlock()
 
 	if cache != nil && time.Since(cacheTime) < routeCacheTTL {
@@ -45,8 +83,14 @@ func (p *Provider) routes(ctx provider.BaseContext) (repository.RouteRepository,
 	}
 
 	p.mu.Lock()
-	p.routeCache = repo
-	p.routeCacheTime = time.Now()
+	// Only write back if no invalidation happened while PHP was running.
+	if p.routeGen == gen {
+		log.WithField("routes", len(repo)).WithField("gen", gen).Debug("routes: PHP call complete, storing in cache")
+		p.routeCache = repo
+		p.routeCacheTime = time.Now()
+	} else {
+		log.WithField("gen_expected", gen).WithField("gen_current", p.routeGen).Debug("routes: PHP result discarded (invalidated during call)")
+	}
 	p.mu.Unlock()
 
 	return repo, nil
@@ -58,6 +102,7 @@ func (p *Provider) Register(manager *provider.Manager) {
 
 func (p *Provider) Init(ctx provider.InitContext) {
 	p.rootPath = ctx.RootPath
+	p.project = ctx.Project
 }
 
 func (p *Provider) Hover(ctx provider.HoverContext) {

--- a/laravel/providers/route/provider.go
+++ b/laravel/providers/route/provider.go
@@ -69,7 +69,7 @@ func (p *Provider) OnFileSaved(filename string) <-chan struct{} {
 // routes returns the route repository, cached in memory and invalidated on
 // routes file save. The first call after startup or invalidation spawns a
 // PHP process to load the routes; subsequent calls return the cached result.
-func (p *Provider) routes(ctx provider.BaseContext) (repository.RouteRepository, error) {
+func (p *Provider) routes() (repository.RouteRepository, error) {
 	p.mu.Lock()
 	cache, gen := p.routeCache, p.routeGen
 	p.mu.Unlock()
@@ -78,7 +78,11 @@ func (p *Provider) routes(ctx provider.BaseContext) (repository.RouteRepository,
 		return cache, nil
 	}
 
-	repo, err := ctx.Project.Routes()
+	if p.project == nil {
+		return nil, fmt.Errorf("routes: provider not initialized")
+	}
+
+	repo, err := p.project.Routes()
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +120,7 @@ func (p *Provider) Hover(ctx provider.HoverContext) {
 		return
 	}
 
-	repo, err := p.routes(ctx.BaseContext)
+	repo, err := p.routes()
 	if err != nil {
 		ctx.Logger.WithError(err).Warn("failed to get repo")
 		return
@@ -140,7 +144,7 @@ func (p *Provider) ResolveCompletion(ctx provider.CompletionContext) {
 
 	text := php.GetStringContent(node, ctx.File.Src)
 
-	repo, err := p.routes(ctx.BaseContext)
+	repo, err := p.routes()
 	if err != nil {
 		ctx.Logger.WithError(err).Warn("failed to get repo")
 		return
@@ -162,7 +166,7 @@ func (p *Provider) ResolveDefinition(ctx provider.DefinitionContext) {
 		return
 	}
 
-	repo, err := p.routes(ctx.BaseContext)
+	repo, err := p.routes()
 	if err != nil {
 		ctx.Logger.WithError(err).Warn("failed to get repo")
 		return
@@ -179,7 +183,7 @@ func (p *Provider) Diagnostic(ctx provider.DiagnosticContext) {
 		return
 	}
 
-	repo, err := p.routes(ctx.BaseContext)
+	repo, err := p.routes()
 	if err != nil {
 		ctx.Logger.WithError(err).Warn("failed to get repo")
 		return
@@ -208,7 +212,7 @@ func (p *Provider) ResolveCodeAction(ctx provider.CodeActionContext) {
 		return
 	}
 
-	repo, err := p.routes(ctx.BaseContext)
+	repo, err := p.routes()
 	if err != nil {
 		ctx.Logger.WithError(err).Warn("failed to get repo")
 		return

--- a/laravel/providers/route/provider.go
+++ b/laravel/providers/route/provider.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/laravel-ls/laravel-ls/file"
 	"github.com/laravel-ls/laravel-ls/laravel/providers/route/queries"
+	"github.com/laravel-ls/laravel-ls/project"
 	"github.com/laravel-ls/laravel-ls/provider"
 	"github.com/laravel-ls/laravel-ls/treesitter/php"
 	"github.com/laravel-ls/laravel-ls/utils/repository"
@@ -20,7 +21,7 @@ const routeCacheTTL = 30 * time.Second
 
 type Provider struct {
 	rootPath string
-	project  interface{ Routes() (repository.RouteRepository, error) }
+	project  *project.Project
 
 	mu             sync.Mutex
 	routeCache     repository.RouteRepository
@@ -38,6 +39,10 @@ func NewProvider() *Provider {
 func (p *Provider) OnFileSaved(filename string) <-chan struct{} {
 	routesDir := path.Join(p.rootPath, "routes") + "/"
 	if !strings.HasPrefix(filename, routesDir) {
+		return nil
+	}
+
+	if p.project == nil {
 		return nil
 	}
 

--- a/laravel/providers/route/provider.go
+++ b/laravel/providers/route/provider.go
@@ -3,20 +3,53 @@ package route
 import (
 	"fmt"
 	"path"
+	"sync"
+	"time"
 
 	"github.com/laravel-ls/laravel-ls/file"
 	"github.com/laravel-ls/laravel-ls/laravel/providers/route/queries"
 	"github.com/laravel-ls/laravel-ls/provider"
 	"github.com/laravel-ls/laravel-ls/treesitter/php"
+	"github.com/laravel-ls/laravel-ls/utils/repository"
 	"github.com/laravel-ls/protocol"
 )
 
+const routeCacheTTL = 30 * time.Second
+
 type Provider struct {
 	rootPath string
+
+	mu             sync.Mutex
+	routeCache     repository.RouteRepository
+	routeCacheTime time.Time
 }
 
 func NewProvider() *Provider {
 	return &Provider{}
+}
+
+// routes returns the route repository, using a short-lived cache to avoid
+// spawning a PHP process on every inlay hint refresh.
+func (p *Provider) routes(ctx provider.BaseContext) (repository.RouteRepository, error) {
+	p.mu.Lock()
+	cache, cacheTime := p.routeCache, p.routeCacheTime
+	p.mu.Unlock()
+
+	if cache != nil && time.Since(cacheTime) < routeCacheTTL {
+		return cache, nil
+	}
+
+	repo, err := ctx.Project.Routes()
+	if err != nil {
+		return nil, err
+	}
+
+	p.mu.Lock()
+	p.routeCache = repo
+	p.routeCacheTime = time.Now()
+	p.mu.Unlock()
+
+	return repo, nil
 }
 
 func (p *Provider) Register(manager *provider.Manager) {
@@ -38,7 +71,7 @@ func (p *Provider) Hover(ctx provider.HoverContext) {
 		return
 	}
 
-	repo, err := ctx.Project.Routes()
+	repo, err := p.routes(ctx.BaseContext)
 	if err != nil {
 		ctx.Logger.WithError(err).Warn("failed to get repo")
 		return
@@ -62,7 +95,7 @@ func (p *Provider) ResolveCompletion(ctx provider.CompletionContext) {
 
 	text := php.GetStringContent(node, ctx.File.Src)
 
-	repo, err := ctx.Project.Routes()
+	repo, err := p.routes(ctx.BaseContext)
 	if err != nil {
 		ctx.Logger.WithError(err).Warn("failed to get repo")
 		return
@@ -84,7 +117,7 @@ func (p *Provider) ResolveDefinition(ctx provider.DefinitionContext) {
 		return
 	}
 
-	repo, err := ctx.Project.Routes()
+	repo, err := p.routes(ctx.BaseContext)
 	if err != nil {
 		ctx.Logger.WithError(err).Warn("failed to get repo")
 		return
@@ -101,7 +134,7 @@ func (p *Provider) Diagnostic(ctx provider.DiagnosticContext) {
 		return
 	}
 
-	repo, err := ctx.Project.Routes()
+	repo, err := p.routes(ctx.BaseContext)
 	if err != nil {
 		ctx.Logger.WithError(err).Warn("failed to get repo")
 		return
@@ -130,7 +163,7 @@ func (p *Provider) ResolveCodeAction(ctx provider.CodeActionContext) {
 		return
 	}
 
-	repo, err := ctx.Project.Routes()
+	repo, err := p.routes(ctx.BaseContext)
 	if err != nil {
 		ctx.Logger.WithError(err).Warn("failed to get repo")
 		return

--- a/lsp/server/config.go
+++ b/lsp/server/config.go
@@ -1,0 +1,39 @@
+package server
+
+// LSPConfig holds configuration passed by the client via initializationOptions
+// during the LSP initialize handshake.
+//
+// In Neovim (lsp/laravel_ls.lua), set these via init_options:
+//
+//	init_options = {
+//	  capabilities = {
+//	    inlayHints = {
+//	      routes = { enabled = false }
+//	    }
+//	  }
+//	}
+type LSPConfig struct {
+	Capabilities CapabilitiesConfig `json:"capabilities"`
+}
+
+// CapabilitiesConfig controls which server capabilities are active.
+type CapabilitiesConfig struct {
+	InlayHints InlayHintsConfig `json:"inlayHints"`
+}
+
+// InlayHintsConfig controls inlay hint support per feature area.
+type InlayHintsConfig struct {
+	Routes RouteInlayHintsConfig `json:"routes"`
+}
+
+// RouteInlayHintsConfig controls route inlay hints, which display the HTTP
+// method and URI above matching controller action methods.
+// Enabled defaults to true when not explicitly set.
+type RouteInlayHintsConfig struct {
+	Enabled *bool `json:"enabled"`
+}
+
+// IsEnabled returns true unless explicitly set to false.
+func (c RouteInlayHintsConfig) IsEnabled() bool {
+	return c.Enabled == nil || *c.Enabled
+}

--- a/lsp/server/config.go
+++ b/lsp/server/config.go
@@ -3,7 +3,7 @@ package server
 // LSPConfig holds configuration passed by the client via initializationOptions
 // during the LSP initialize handshake.
 //
-// In Neovim (lsp/laravel_ls.lua), set these via init_options:
+// e.g. In Neovim (lsp/laravel_ls.lua), set these via init_options:
 //
 //	init_options = {
 //	  inlayHints = {
@@ -14,19 +14,14 @@ type LSPConfig struct {
 	InlayHints InlayHintsConfig `json:"inlayHints"`
 }
 
-// InlayHintsConfig controls inlay hint support per feature area.
 type InlayHintsConfig struct {
 	Routes RouteInlayHintsConfig `json:"routes"`
 }
 
-// RouteInlayHintsConfig controls route inlay hints, which display the HTTP
-// method and URI above matching controller action methods.
-// Enabled defaults to true when not explicitly set.
 type RouteInlayHintsConfig struct {
 	Enabled *bool `json:"enabled"`
 }
 
-// IsEnabled returns true unless explicitly set to false.
 func (c RouteInlayHintsConfig) IsEnabled() bool {
 	return c.Enabled == nil || *c.Enabled
 }

--- a/lsp/server/config.go
+++ b/lsp/server/config.go
@@ -6,18 +6,11 @@ package server
 // In Neovim (lsp/laravel_ls.lua), set these via init_options:
 //
 //	init_options = {
-//	  capabilities = {
-//	    inlayHints = {
-//	      routes = { enabled = false }
-//	    }
+//	  inlayHints = {
+//	    routes = { enabled = false }
 //	  }
 //	}
 type LSPConfig struct {
-	Capabilities CapabilitiesConfig `json:"capabilities"`
-}
-
-// CapabilitiesConfig controls which server capabilities are active.
-type CapabilitiesConfig struct {
 	InlayHints InlayHintsConfig `json:"inlayHints"`
 }
 

--- a/lsp/server/config_test.go
+++ b/lsp/server/config_test.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestRouteInlayHintsIsEnabled(t *testing.T) {
+	t.Run("nil pointer defaults to enabled", func(t *testing.T) {
+		c := RouteInlayHintsConfig{Enabled: nil}
+		require.True(t, c.IsEnabled())
+	})
+
+	t.Run("explicit true is enabled", func(t *testing.T) {
+		c := RouteInlayHintsConfig{Enabled: boolPtr(true)}
+		require.True(t, c.IsEnabled())
+	})
+
+	t.Run("explicit false is disabled", func(t *testing.T) {
+		c := RouteInlayHintsConfig{Enabled: boolPtr(false)}
+		require.False(t, c.IsEnabled())
+	})
+}

--- a/lsp/server/server.go
+++ b/lsp/server/server.go
@@ -24,7 +24,6 @@ var (
 	ErrFailedToGetPointAtCursor = errors.New("failed to get node at cursor")
 )
 
-
 type Server struct {
 	// Map of open files for this session
 	cache *cache.FileCache
@@ -375,8 +374,10 @@ func (s *Server) HandleTextDocumentInlayHint(params protocol.InlayHintParams) ([
 		},
 		Range: toTSRange(params.Range),
 		Publish: func(hint provider.InlayHint) {
+			paddingLeft := true
 			response = append(response, protocol.InlayHint{
-				Position: FromTSPoint(hint.Position),
+				Position:    FromTSPoint(hint.Position),
+				PaddingLeft: &paddingLeft,
 				Label: protocol.InlayHintLabel{
 					String: &hint.Label,
 				},

--- a/lsp/server/server.go
+++ b/lsp/server/server.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sync"
 
 	"github.com/laravel-ls/laravel-ls/cache"
 	"github.com/laravel-ls/laravel-ls/parser"
@@ -63,10 +62,6 @@ type Server struct {
 
 	// config is parsed from initializationOptions during the initialize handshake.
 	config LSPConfig
-
-	// conn is stored on first dispatch so we can send server-initiated requests.
-	conn     *jsonrpc2.Conn
-	connOnce sync.Once
 }
 
 func NewServer(providerManager *provider.Manager) *Server {
@@ -310,15 +305,7 @@ func (s *Server) HandleTextDocumentDidSave(params protocol.DidSaveTextDocumentPa
 		return err
 	}
 
-	if ch := s.providerManager.FileSaved(filename); ch != nil && s.conn != nil {
-		go func() {
-			<-ch // wait until cache is pre-warmed before telling client to refresh
-			var result any
-			if err := s.conn.Call(context.Background(), "workspace/inlayHint/refresh", nil, &result); err != nil {
-				log.WithError(err).Debug("workspace/inlayHint/refresh: client error")
-			}
-		}()
-	}
+	s.providerManager.FileSaved(filename)
 
 	return nil
 }
@@ -417,7 +404,6 @@ func (s *Server) HandleTextDocumentInlayHint(params inlayHintParams) ([]inlayHin
 
 // Handle incoming LSP messages
 func (s *Server) dispatch(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) {
-	s.connOnce.Do(func() { s.conn = conn })
 	switch req.Method {
 	case protocol.MethodTextDocumentCodeAction:
 		var params protocol.CodeActionParams

--- a/lsp/server/server.go
+++ b/lsp/server/server.go
@@ -24,6 +24,32 @@ var (
 	ErrFailedToGetPointAtCursor = errors.New("failed to get node at cursor")
 )
 
+// Local types for inlay hint support (not yet in protocol package)
+type inlayHintParams struct {
+	TextDocument protocol.TextDocumentIdentifier `json:"textDocument"`
+}
+
+type inlayHintResponse struct {
+	Position protocol.Position `json:"position"`
+	Label    string            `json:"label"`
+}
+
+// localServerCapabilities extends protocol.ServerCapabilities with inlay hint support.
+type localServerCapabilities struct {
+	TextDocumentSync   protocol.TextDocumentSyncKind `json:"textDocumentSync"`
+	HoverProvider      bool                          `json:"hoverProvider"`
+	CompletionProvider *protocol.CompletionOptions   `json:"completionProvider,omitempty"`
+	DefinitionProvider bool                          `json:"definitionProvider"`
+	DiagnosticProvider protocol.DiagnosticOptions    `json:"diagnosticProvider"`
+	CodeActionProvider bool                          `json:"codeActionProvider"`
+	InlayHintProvider  bool                          `json:"inlayHintProvider"`
+}
+
+type localInitializeResult struct {
+	Capabilities localServerCapabilities `json:"capabilities"`
+	ServerInfo   *protocol.ServerInfo    `json:"serverInfo,omitempty"`
+}
+
 type Server struct {
 	// Map of open files for this session
 	cache *cache.FileCache
@@ -286,12 +312,12 @@ func (s Server) HandleTextDocumentDidClose(params protocol.DidCloseTextDocumentP
 	return s.cache.Close(filename)
 }
 
-func (s *Server) HandleInitialize(params protocol.InitializeParams) (protocol.InitializeResult, error) {
+func (s *Server) HandleInitialize(params protocol.InitializeParams) (localInitializeResult, error) {
 	rootPath, err := validateURI(string(params.RootURI))
 	if err == ErrNonLocalPath {
-		return protocol.InitializeResult{}, fmt.Errorf("server only support local filesystem root paths")
+		return localInitializeResult{}, fmt.Errorf("server only support local filesystem root paths")
 	} else if err != nil {
-		return protocol.InitializeResult{}, err
+		return localInitializeResult{}, err
 	}
 
 	log.WithField("method", protocol.MethodInitialize).
@@ -305,8 +331,8 @@ func (s *Server) HandleInitialize(params protocol.InitializeParams) (protocol.In
 	})
 
 	// Respond with capabilities
-	return protocol.InitializeResult{
-		Capabilities: protocol.ServerCapabilities{
+	return localInitializeResult{
+		Capabilities: localServerCapabilities{
 			TextDocumentSync: protocol.TextDocumentSyncKindIncremental,
 			HoverProvider:    true,
 			CompletionProvider: &protocol.CompletionOptions{
@@ -318,12 +344,42 @@ func (s *Server) HandleInitialize(params protocol.InitializeParams) (protocol.In
 				WorkspaceDiagnostics:  false,
 			},
 			CodeActionProvider: true,
+			InlayHintProvider:  true,
 		},
 		ServerInfo: &protocol.ServerInfo{
 			Name:    program.Name,
 			Version: program.Version(),
 		},
 	}, nil
+}
+
+func (s *Server) HandleTextDocumentInlayHint(params inlayHintParams) ([]inlayHintResponse, error) {
+	log.WithField("method", "textDocument/inlayHint").
+		WithField("filename", params.TextDocument.URI).
+		Debug("InlayHint")
+
+	response := []inlayHintResponse{}
+
+	file, err := s.getFile(params.TextDocument)
+	if err != nil {
+		return response, err
+	}
+
+	s.providerManager.InlayHints(provider.InlayHintContext{
+		BaseContext: provider.BaseContext{
+			Logger:    log.WithField("module", "InlayHint"),
+			File:      file,
+			FileCache: s.cache,
+		},
+		Publish: func(hint provider.InlayHint) {
+			response = append(response, inlayHintResponse{
+				Position: FromTSPoint(hint.Position),
+				Label:    hint.Label,
+			})
+		},
+	})
+
+	return response, nil
 }
 
 // Handle incoming LSP messages
@@ -393,6 +449,12 @@ func (s *Server) dispatch(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc
 		log.WithField("method", protocol.MethodInitialized).
 			Debug("Initialized")
 		return nil, nil
+	case "textDocument/inlayHint":
+		var params inlayHintParams
+		if err := json.Unmarshal(*req.Params, &params); err != nil {
+			return nil, err
+		}
+		return s.HandleTextDocumentInlayHint(params)
 	case "$/cancelRequest":
 		// See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#cancelRequest
 		// TODO: Maybe implement a way to cancel requests?

--- a/lsp/server/server.go
+++ b/lsp/server/server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/laravel-ls/laravel-ls/cache"
 	"github.com/laravel-ls/laravel-ls/parser"
@@ -59,6 +60,10 @@ type Server struct {
 	shutdownReceived bool
 
 	providerManager *provider.Manager
+
+	// conn is stored on first dispatch so we can send server-initiated requests.
+	conn     *jsonrpc2.Conn
+	connOnce sync.Once
 }
 
 func NewServer(providerManager *provider.Manager) *Server {
@@ -292,10 +297,26 @@ func (s Server) HandleTextDocumentDidChange(params protocol.DidChangeTextDocumen
 	return errs
 }
 
-func (s Server) HandleTextDocumentDidSave(params protocol.DidSaveTextDocumentParams) error {
+func (s *Server) HandleTextDocumentDidSave(params protocol.DidSaveTextDocumentParams) error {
 	log.WithField("method", protocol.MethodTextDocumentDidSave).
 		WithField("filename", params.TextDocument.URI).
 		Debug("Document saved")
+
+	filename, err := validateURI(params.TextDocument.URI)
+	if err != nil {
+		return err
+	}
+
+	if ch := s.providerManager.FileSaved(filename); ch != nil && s.conn != nil {
+		go func() {
+			<-ch // wait until cache is pre-warmed before telling client to refresh
+			var result any
+			if err := s.conn.Call(context.Background(), "workspace/inlayHint/refresh", nil, &result); err != nil {
+				log.WithError(err).Debug("workspace/inlayHint/refresh: client error")
+			}
+		}()
+	}
+
 	return nil
 }
 
@@ -384,6 +405,7 @@ func (s *Server) HandleTextDocumentInlayHint(params inlayHintParams) ([]inlayHin
 
 // Handle incoming LSP messages
 func (s *Server) dispatch(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (any, error) {
+	s.connOnce.Do(func() { s.conn = conn })
 	switch req.Method {
 	case protocol.MethodTextDocumentCodeAction:
 		var params protocol.CodeActionParams

--- a/lsp/server/server.go
+++ b/lsp/server/server.go
@@ -27,6 +27,7 @@ var (
 // Local types for inlay hint support (not yet in protocol package)
 type inlayHintParams struct {
 	TextDocument protocol.TextDocumentIdentifier `json:"textDocument"`
+	Range        protocol.Range                  `json:"range"`
 }
 
 type inlayHintResponse struct {
@@ -305,7 +306,10 @@ func (s *Server) HandleTextDocumentDidSave(params protocol.DidSaveTextDocumentPa
 		return err
 	}
 
-	s.providerManager.FileSaved(filename)
+	// Fire-and-forget: the returned channel closes when providers finish
+	// re-warming, but the server does not wait for it. Callers that need to
+	// synchronise on cache readiness should await the channel themselves.
+	_ = s.providerManager.FileSaved(filename)
 
 	return nil
 }
@@ -337,10 +341,10 @@ func (s *Server) HandleInitialize(params protocol.InitializeParams) (localInitia
 
 	if params.InitializationOptions != nil {
 		raw, err := json.Marshal(params.InitializationOptions)
-		if err == nil {
-			if err := json.Unmarshal(raw, &s.config); err != nil {
-				log.WithError(err).Warn("failed to parse initializationOptions")
-			}
+		if err != nil {
+			log.WithError(err).Warn("failed to marshal initializationOptions")
+		} else if err := json.Unmarshal(raw, &s.config); err != nil {
+			log.WithError(err).Warn("failed to parse initializationOptions")
 		}
 	}
 
@@ -377,6 +381,10 @@ func (s *Server) HandleTextDocumentInlayHint(params inlayHintParams) ([]inlayHin
 	log.WithField("method", "textDocument/inlayHint").
 		WithField("filename", params.TextDocument.URI).
 		Debug("InlayHint")
+
+	if !s.config.InlayHints.Routes.IsEnabled() {
+		return []inlayHintResponse{}, nil
+	}
 
 	response := []inlayHintResponse{}
 
@@ -469,6 +477,8 @@ func (s *Server) dispatch(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc
 		log.WithField("method", protocol.MethodInitialized).
 			Debug("Initialized")
 		return nil, nil
+	// "textDocument/inlayHint" is used as a string literal because the
+	// protocol package does not yet define a constant for this method.
 	case "textDocument/inlayHint":
 		var params inlayHintParams
 		if err := json.Unmarshal(*req.Params, &params); err != nil {

--- a/lsp/server/server.go
+++ b/lsp/server/server.go
@@ -24,32 +24,6 @@ var (
 	ErrFailedToGetPointAtCursor = errors.New("failed to get node at cursor")
 )
 
-// Local types for inlay hint support (not yet in protocol package)
-type inlayHintParams struct {
-	TextDocument protocol.TextDocumentIdentifier `json:"textDocument"`
-	Range        protocol.Range                  `json:"range"`
-}
-
-type inlayHintResponse struct {
-	Position protocol.Position `json:"position"`
-	Label    string            `json:"label"`
-}
-
-// localServerCapabilities extends protocol.ServerCapabilities with inlay hint support.
-type localServerCapabilities struct {
-	TextDocumentSync   protocol.TextDocumentSyncKind `json:"textDocumentSync"`
-	HoverProvider      bool                          `json:"hoverProvider"`
-	CompletionProvider *protocol.CompletionOptions   `json:"completionProvider,omitempty"`
-	DefinitionProvider bool                          `json:"definitionProvider"`
-	DiagnosticProvider protocol.DiagnosticOptions    `json:"diagnosticProvider"`
-	CodeActionProvider bool                          `json:"codeActionProvider"`
-	InlayHintProvider  bool                          `json:"inlayHintProvider"`
-}
-
-type localInitializeResult struct {
-	Capabilities localServerCapabilities `json:"capabilities"`
-	ServerInfo   *protocol.ServerInfo    `json:"serverInfo,omitempty"`
-}
 
 type Server struct {
 	// Map of open files for this session
@@ -327,12 +301,12 @@ func (s Server) HandleTextDocumentDidClose(params protocol.DidCloseTextDocumentP
 	return s.cache.Close(filename)
 }
 
-func (s *Server) HandleInitialize(params protocol.InitializeParams) (localInitializeResult, error) {
+func (s *Server) HandleInitialize(params protocol.InitializeParams) (protocol.InitializeResult, error) {
 	rootPath, err := validateURI(string(params.RootURI))
 	if err == ErrNonLocalPath {
-		return localInitializeResult{}, fmt.Errorf("server only support local filesystem root paths")
+		return protocol.InitializeResult{}, fmt.Errorf("server only support local filesystem root paths")
 	} else if err != nil {
-		return localInitializeResult{}, err
+		return protocol.InitializeResult{}, err
 	}
 
 	log.WithField("method", protocol.MethodInitialize).
@@ -355,8 +329,8 @@ func (s *Server) HandleInitialize(params protocol.InitializeParams) (localInitia
 	})
 
 	// Respond with capabilities
-	return localInitializeResult{
-		Capabilities: localServerCapabilities{
+	return protocol.InitializeResult{
+		Capabilities: protocol.ServerCapabilities{
 			TextDocumentSync: protocol.TextDocumentSyncKindIncremental,
 			HoverProvider:    true,
 			CompletionProvider: &protocol.CompletionOptions{
@@ -377,16 +351,16 @@ func (s *Server) HandleInitialize(params protocol.InitializeParams) (localInitia
 	}, nil
 }
 
-func (s *Server) HandleTextDocumentInlayHint(params inlayHintParams) ([]inlayHintResponse, error) {
-	log.WithField("method", "textDocument/inlayHint").
+func (s *Server) HandleTextDocumentInlayHint(params protocol.InlayHintParams) ([]protocol.InlayHint, error) {
+	log.WithField("method", protocol.MethodTextDocumentInlayHint).
 		WithField("filename", params.TextDocument.URI).
 		Debug("InlayHint")
 
-	if !s.config.InlayHints.Routes.IsEnabled() {
-		return []inlayHintResponse{}, nil
-	}
+	response := []protocol.InlayHint{}
 
-	response := []inlayHintResponse{}
+	if !s.config.InlayHints.Routes.IsEnabled() {
+		return response, nil
+	}
 
 	file, err := s.getFile(params.TextDocument)
 	if err != nil {
@@ -399,10 +373,13 @@ func (s *Server) HandleTextDocumentInlayHint(params inlayHintParams) ([]inlayHin
 			File:      file,
 			FileCache: s.cache,
 		},
+		Range: toTSRange(params.Range),
 		Publish: func(hint provider.InlayHint) {
-			response = append(response, inlayHintResponse{
+			response = append(response, protocol.InlayHint{
 				Position: FromTSPoint(hint.Position),
-				Label:    hint.Label,
+				Label: protocol.InlayHintLabel{
+					String: &hint.Label,
+				},
 			})
 		},
 	})
@@ -477,10 +454,8 @@ func (s *Server) dispatch(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc
 		log.WithField("method", protocol.MethodInitialized).
 			Debug("Initialized")
 		return nil, nil
-	// "textDocument/inlayHint" is used as a string literal because the
-	// protocol package does not yet define a constant for this method.
-	case "textDocument/inlayHint":
-		var params inlayHintParams
+	case protocol.MethodTextDocumentInlayHint:
+		var params protocol.InlayHintParams
 		if err := json.Unmarshal(*req.Params, &params); err != nil {
 			return nil, err
 		}

--- a/lsp/server/server.go
+++ b/lsp/server/server.go
@@ -377,7 +377,7 @@ func (s *Server) HandleInitialize(params protocol.InitializeParams) (localInitia
 				WorkspaceDiagnostics:  false,
 			},
 			CodeActionProvider: true,
-			InlayHintProvider:  s.config.Capabilities.InlayHints.Routes.IsEnabled(),
+			InlayHintProvider:  s.config.InlayHints.Routes.IsEnabled(),
 		},
 		ServerInfo: &protocol.ServerInfo{
 			Name:    program.Name,

--- a/lsp/server/server.go
+++ b/lsp/server/server.go
@@ -61,6 +61,9 @@ type Server struct {
 
 	providerManager *provider.Manager
 
+	// config is parsed from initializationOptions during the initialize handshake.
+	config LSPConfig
+
 	// conn is stored on first dispatch so we can send server-initiated requests.
 	conn     *jsonrpc2.Conn
 	connOnce sync.Once
@@ -345,6 +348,15 @@ func (s *Server) HandleInitialize(params protocol.InitializeParams) (localInitia
 		WithField("rootPath", rootPath).
 		Debug("Initialize")
 
+	if params.InitializationOptions != nil {
+		raw, err := json.Marshal(params.InitializationOptions)
+		if err == nil {
+			if err := json.Unmarshal(raw, &s.config); err != nil {
+				log.WithError(err).Warn("failed to parse initializationOptions")
+			}
+		}
+	}
+
 	s.providerManager.Init(provider.InitContext{
 		Logger:    log.WithField("module", "Initialize"),
 		RootPath:  rootPath,
@@ -365,7 +377,7 @@ func (s *Server) HandleInitialize(params protocol.InitializeParams) (localInitia
 				WorkspaceDiagnostics:  false,
 			},
 			CodeActionProvider: true,
-			InlayHintProvider:  true,
+			InlayHintProvider:  s.config.Capabilities.InlayHints.Routes.IsEnabled(),
 		},
 		ServerInfo: &protocol.ServerInfo{
 			Name:    program.Name,

--- a/project/scripts/app_gen.php
+++ b/project/scripts/app_gen.php
@@ -7,18 +7,14 @@ $kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
 $kernel->bootstrap();
 
 
-
 echo collect(app()->getBindings())
     ->filter(fn ($binding) => ($binding['concrete'] ?? null) !== null)
     ->flatMap(function ($binding, $key) {
         $boundTo = new ReflectionFunction($binding['concrete']);
-
         $closureClass = $boundTo->getClosureScopeClass();
-
         if ($closureClass === null) {
             return [];
         }
-
         return [
             $key => [
                 'path' => $closureClass->getFileName(),

--- a/project/scripts/app_gen.php
+++ b/project/scripts/app_gen.php
@@ -7,14 +7,18 @@ $kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
 $kernel->bootstrap();
 
 
+
 echo collect(app()->getBindings())
     ->filter(fn ($binding) => ($binding['concrete'] ?? null) !== null)
     ->flatMap(function ($binding, $key) {
         $boundTo = new ReflectionFunction($binding['concrete']);
+
         $closureClass = $boundTo->getClosureScopeClass();
+
         if ($closureClass === null) {
             return [];
         }
+
         return [
             $key => [
                 'path' => $closureClass->getFileName(),

--- a/project/scripts/configs_gen.php
+++ b/project/scripts/configs_gen.php
@@ -7,6 +7,7 @@ $kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
 $kernel->bootstrap();
 
 
+
 $local = collect(glob(config_path("/*.php")))
   ->merge(glob(config_path("**/*.php")))
   ->map(fn ($path) => [
@@ -15,6 +16,7 @@ $local = collect(glob(config_path("/*.php")))
         ->replace(DIRECTORY_SEPARATOR, "."),
       $path
     ]);
+
 $vendor = collect(glob(base_path("vendor/**/**/config/*.php")))->map(fn (
   $path
 ) => [
@@ -24,63 +26,83 @@ $vendor = collect(glob(base_path("vendor/**/**/config/*.php")))->map(fn (
       ->replace(DIRECTORY_SEPARATOR, "."),
     $path
   ]);
+
 $configPaths = $local
   ->merge($vendor)
   ->groupBy(0)
   ->map(fn ($items)=>$items->pluck(1));
+
 $cachedContents = [];
 $cachedParsed = [];
+
 function vsCodeGetConfigValue($value, $key, $configPaths) {
     $parts = explode(".", $key);
     $toFind = $key;
     $found = null;
+
     while (count($parts) > 0) {
       $toFind = implode(".", $parts);
+
       if ($configPaths->has($toFind)) {
         $found = $toFind;
         break;
       }
+
       array_pop($parts);
     }
+
     if ($found === null) {
       return null;
     }
+
     $file = null;
     $line = null;
+
     if ($found === $key) {
       $file = $configPaths->get($found)[0];
     } else {
       foreach ($configPaths->get($found) as $path) {
         $cachedContents[$path] ??= file_get_contents($path);
         $cachedParsed[$path] ??= token_get_all($cachedContents[$path]);
+
         $keysToFind = \Illuminate\Support\Str::of($key)
           ->replaceFirst($found, "")
           ->ltrim(".")
           ->explode(".");
+
         if (is_numeric($keysToFind->last())) {
           $index = $keysToFind->pop();
+
           if ($index !== "0") {
             return null;
           }
+
           $key = collect(explode(".", $key));
           $key->pop();
           $key = $key->implode(".");
           $value = "array(...)";
         }
+
         $nextKey = $keysToFind->shift();
         $expectedDepth = 1;
+
         $depth = 0;
+
         foreach ($cachedParsed[$path] as $token) {
           if ($token === "[") {
             $depth++;
           }
+
           if ($token === "]") {
             $depth--;
           }
+
           if (!is_array($token)) {
             continue;
           }
+
           $str = trim($token[1], '"\'');
+
           if (
             $str === $nextKey &&
             $depth === $expectedDepth &&
@@ -88,6 +110,7 @@ function vsCodeGetConfigValue($value, $key, $configPaths) {
           ) {
             $nextKey = $keysToFind->shift();
             $expectedDepth++;
+
             if ($nextKey === null) {
               $file = $path;
               $line = $token[2];
@@ -95,27 +118,33 @@ function vsCodeGetConfigValue($value, $key, $configPaths) {
             }
           }
         }
+
         if ($file) {
           break;
         }
       }
     }
+
     return [
       "value" => $value,
       "file" => $file === null ? null : str_replace(base_path(DIRECTORY_SEPARATOR), '', $file),
       "line" => $line
     ];
 }
+
 function vsCodeUnpackDottedKey($value, $key) {
   $arr = [$key => $value];
   $parts = explode('.', $key);
   array_pop($parts);
+
   while (count($parts)) {
     $arr[implode('.', $parts)] = 'array(...)';
     array_pop($parts);
   }
+
   return $arr;
 }
+
 echo collect(\Illuminate\Support\Arr::dot(config()->all()))
   ->mapWithKeys(fn($value, $key) => vsCodeUnpackDottedKey($value, $key))
   ->map(fn ($value, $key) => vsCodeGetConfigValue($value, $key, $configPaths))

--- a/project/scripts/configs_gen.php
+++ b/project/scripts/configs_gen.php
@@ -7,7 +7,6 @@ $kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
 $kernel->bootstrap();
 
 
-
 $local = collect(glob(config_path("/*.php")))
   ->merge(glob(config_path("**/*.php")))
   ->map(fn ($path) => [
@@ -16,7 +15,6 @@ $local = collect(glob(config_path("/*.php")))
         ->replace(DIRECTORY_SEPARATOR, "."),
       $path
     ]);
-
 $vendor = collect(glob(base_path("vendor/**/**/config/*.php")))->map(fn (
   $path
 ) => [
@@ -26,83 +24,63 @@ $vendor = collect(glob(base_path("vendor/**/**/config/*.php")))->map(fn (
       ->replace(DIRECTORY_SEPARATOR, "."),
     $path
   ]);
-
 $configPaths = $local
   ->merge($vendor)
   ->groupBy(0)
   ->map(fn ($items)=>$items->pluck(1));
-
 $cachedContents = [];
 $cachedParsed = [];
-
 function vsCodeGetConfigValue($value, $key, $configPaths) {
     $parts = explode(".", $key);
     $toFind = $key;
     $found = null;
-
     while (count($parts) > 0) {
       $toFind = implode(".", $parts);
-
       if ($configPaths->has($toFind)) {
         $found = $toFind;
         break;
       }
-
       array_pop($parts);
     }
-
     if ($found === null) {
       return null;
     }
-
     $file = null;
     $line = null;
-
     if ($found === $key) {
       $file = $configPaths->get($found)[0];
     } else {
       foreach ($configPaths->get($found) as $path) {
         $cachedContents[$path] ??= file_get_contents($path);
         $cachedParsed[$path] ??= token_get_all($cachedContents[$path]);
-
         $keysToFind = \Illuminate\Support\Str::of($key)
           ->replaceFirst($found, "")
           ->ltrim(".")
           ->explode(".");
-
         if (is_numeric($keysToFind->last())) {
           $index = $keysToFind->pop();
-
           if ($index !== "0") {
             return null;
           }
-
           $key = collect(explode(".", $key));
           $key->pop();
           $key = $key->implode(".");
           $value = "array(...)";
         }
-
         $nextKey = $keysToFind->shift();
         $expectedDepth = 1;
-
         $depth = 0;
-
         foreach ($cachedParsed[$path] as $token) {
           if ($token === "[") {
             $depth++;
           }
-
           if ($token === "]") {
             $depth--;
           }
-
           if (!is_array($token)) {
             continue;
           }
-
           $str = trim($token[1], '"\'');
-
           if (
             $str === $nextKey &&
             $depth === $expectedDepth &&
@@ -110,7 +88,6 @@ function vsCodeGetConfigValue($value, $key, $configPaths) {
           ) {
             $nextKey = $keysToFind->shift();
             $expectedDepth++;
-
             if ($nextKey === null) {
               $file = $path;
               $line = $token[2];
@@ -118,33 +95,27 @@ function vsCodeGetConfigValue($value, $key, $configPaths) {
             }
           }
         }
-
         if ($file) {
           break;
         }
       }
     }
-
     return [
       "value" => $value,
       "file" => $file === null ? null : str_replace(base_path(DIRECTORY_SEPARATOR), '', $file),
       "line" => $line
     ];
 }
-
 function vsCodeUnpackDottedKey($value, $key) {
   $arr = [$key => $value];
   $parts = explode('.', $key);
   array_pop($parts);
-
   while (count($parts)) {
     $arr[implode('.', $parts)] = 'array(...)';
     array_pop($parts);
   }
-
   return $arr;
 }
-
 echo collect(\Illuminate\Support\Arr::dot(config()->all()))
   ->mapWithKeys(fn($value, $key) => vsCodeUnpackDottedKey($value, $key))
   ->map(fn ($value, $key) => vsCodeGetConfigValue($value, $key, $configPaths))

--- a/project/scripts/routes.php
+++ b/project/scripts/routes.php
@@ -96,4 +96,9 @@ $routes = new class {
     }
 };
 
-echo $routes->all()->filter(fn($route) => !empty($route['name']))->mapWithKeys(fn($route) => [$route['name'] => $route])->toJson();
+echo $routes->all()->mapWithKeys(function($route) {
+    // Named routes keep their name as key (used for route() completion/hover/diagnostics).
+    // Unnamed routes are keyed by action::uri so they are still available for inlay hints.
+    $key = !empty($route['name']) ? $route['name'] : ($route['action'] . '::' . $route['uri']);
+    return [$key => $route];
+})->toJson();

--- a/project/scripts/routes_gen.php
+++ b/project/scripts/routes_gen.php
@@ -7,7 +7,6 @@ $kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
 $kernel->bootstrap();
 
 
-
 $routes = new class {
     public function all()
     {
@@ -15,22 +14,17 @@ $routes = new class {
             ->map(fn(\Illuminate\Routing\Route $route) => $this->getRoute($route))
             ->merge($this->getFolioRoutes());
     }
-
     protected function getFolioRoutes()
     {
         try {
             $output = new \Symfony\Component\Console\Output\BufferedOutput();
-
             \Illuminate\Support\Facades\Artisan::call("folio:list", ["--json" => true], $output);
-
             $mountPaths = collect(app(\Laravel\Folio\FolioManager::class)->mountPaths());
-
             return collect(json_decode($output->fetch(), true))->map(fn($route) => $this->getFolioRoute($route, $mountPaths));
         } catch (\Exception | \Throwable $e) {
             return [];
         }
     }
-
     protected function getFolioRoute($route, $mountPaths)
     {
         if ($mountPaths->count() === 1) {
@@ -38,13 +32,10 @@ $routes = new class {
         } else {
             $mountPath = $mountPaths->first(fn($mp) => file_exists($mp->path . DIRECTORY_SEPARATOR . $route['view']));
         }
-
         $path = $route['view'];
-
         if ($mountPath) {
             $path = $mountPath->path . DIRECTORY_SEPARATOR . $path;
         }
-
         return [
             'method' => $route['method'],
             'uri' => $route['uri'],
@@ -55,7 +46,6 @@ $routes = new class {
             'line' => 0,
         ];
     }
-
     protected function getRoute(\Illuminate\Routing\Route $route)
     {
         try {
@@ -63,7 +53,6 @@ $routes = new class {
         } catch (\Throwable $e) {
             $reflection = null;
         }
-
         return [
             'method' => collect($route->methods())
                 ->filter(fn($method) => $method !== 'HEAD')
@@ -76,23 +65,19 @@ $routes = new class {
             'line' => $reflection ? $reflection->getStartLine() : null,
         ];
     }
-
     protected function getRouteReflection(\Illuminate\Routing\Route $route)
     {
         if ($route->getActionName() === 'Closure') {
             return new \ReflectionFunction($route->getAction()['uses']);
         }
-
         if (!str_contains($route->getActionName(), '@')) {
             return new \ReflectionClass($route->getActionName());
         }
-
         try {
             return new \ReflectionMethod($route->getControllerClass(), $route->getActionMethod());
         } catch (\Throwable $e) {
             $namespace = app(\Illuminate\Routing\UrlGenerator::class)->getRootControllerNamespace()
                 ?? (app()->getNamespace() . 'Http\Controllers');
-
             return new \ReflectionMethod(
                 $namespace . '\\' . ltrim($route->getControllerClass(), '\\'),
                 $route->getActionMethod(),
@@ -100,5 +85,7 @@ $routes = new class {
         }
     }
 };
-
-echo $routes->all()->filter(fn($route) => !empty($route['name']))->mapWithKeys(fn($route) => [$route['name'] => $route])->toJson();
+echo $routes->all()->mapWithKeys(function($route) {
+    $key = !empty($route['name']) ? $route['name'] : ($route['action'] . '::' . $route['uri']);
+    return [$key => $route];
+})->toJson();

--- a/project/scripts/routes_gen.php
+++ b/project/scripts/routes_gen.php
@@ -7,6 +7,7 @@ $kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
 $kernel->bootstrap();
 
 
+
 $routes = new class {
     public function all()
     {
@@ -14,17 +15,22 @@ $routes = new class {
             ->map(fn(\Illuminate\Routing\Route $route) => $this->getRoute($route))
             ->merge($this->getFolioRoutes());
     }
+
     protected function getFolioRoutes()
     {
         try {
             $output = new \Symfony\Component\Console\Output\BufferedOutput();
+
             \Illuminate\Support\Facades\Artisan::call("folio:list", ["--json" => true], $output);
+
             $mountPaths = collect(app(\Laravel\Folio\FolioManager::class)->mountPaths());
+
             return collect(json_decode($output->fetch(), true))->map(fn($route) => $this->getFolioRoute($route, $mountPaths));
         } catch (\Exception | \Throwable $e) {
             return [];
         }
     }
+
     protected function getFolioRoute($route, $mountPaths)
     {
         if ($mountPaths->count() === 1) {
@@ -32,10 +38,13 @@ $routes = new class {
         } else {
             $mountPath = $mountPaths->first(fn($mp) => file_exists($mp->path . DIRECTORY_SEPARATOR . $route['view']));
         }
+
         $path = $route['view'];
+
         if ($mountPath) {
             $path = $mountPath->path . DIRECTORY_SEPARATOR . $path;
         }
+
         return [
             'method' => $route['method'],
             'uri' => $route['uri'],
@@ -46,6 +55,7 @@ $routes = new class {
             'line' => 0,
         ];
     }
+
     protected function getRoute(\Illuminate\Routing\Route $route)
     {
         try {
@@ -53,6 +63,7 @@ $routes = new class {
         } catch (\Throwable $e) {
             $reflection = null;
         }
+
         return [
             'method' => collect($route->methods())
                 ->filter(fn($method) => $method !== 'HEAD')
@@ -65,19 +76,23 @@ $routes = new class {
             'line' => $reflection ? $reflection->getStartLine() : null,
         ];
     }
+
     protected function getRouteReflection(\Illuminate\Routing\Route $route)
     {
         if ($route->getActionName() === 'Closure') {
             return new \ReflectionFunction($route->getAction()['uses']);
         }
+
         if (!str_contains($route->getActionName(), '@')) {
             return new \ReflectionClass($route->getActionName());
         }
+
         try {
             return new \ReflectionMethod($route->getControllerClass(), $route->getActionMethod());
         } catch (\Throwable $e) {
             $namespace = app(\Illuminate\Routing\UrlGenerator::class)->getRootControllerNamespace()
                 ?? (app()->getNamespace() . 'Http\Controllers');
+
             return new \ReflectionMethod(
                 $namespace . '\\' . ltrim($route->getControllerClass(), '\\'),
                 $route->getActionMethod(),
@@ -85,7 +100,5 @@ $routes = new class {
         }
     }
 };
-echo $routes->all()->mapWithKeys(function($route) {
-    $key = !empty($route['name']) ? $route['name'] : ($route['action'] . '::' . $route['uri']);
-    return [$key => $route];
-})->toJson();
+
+echo $routes->all()->filter(fn($route) => !empty($route['name']))->mapWithKeys(fn($route) => [$route['name'] => $route])->toJson();

--- a/provider/file_save.go
+++ b/provider/file_save.go
@@ -1,0 +1,10 @@
+package provider
+
+// FileSaveProvider can be implemented by providers that need to react to
+// file save events (e.g. to invalidate caches).
+// OnFileSaved returns a channel that closes when the provider's cache has
+// been re-warmed, or nil if no async work is needed (or the file was not
+// relevant to this provider).
+type FileSaveProvider interface {
+	OnFileSaved(filename string) <-chan struct{}
+}

--- a/provider/inlay_hint.go
+++ b/provider/inlay_hint.go
@@ -1,0 +1,19 @@
+package provider
+
+import ts "github.com/tree-sitter/go-tree-sitter"
+
+type InlayHint struct {
+	Position ts.Point
+	Label    string
+}
+
+type InlayHintPublish func(InlayHint)
+
+type InlayHintContext struct {
+	BaseContext
+	Publish InlayHintPublish
+}
+
+type InlayHintProvider interface {
+	ResolveInlayHints(InlayHintContext)
+}

--- a/provider/inlay_hint.go
+++ b/provider/inlay_hint.go
@@ -11,6 +11,9 @@ type InlayHintPublish func(InlayHint)
 
 type InlayHintContext struct {
 	BaseContext
+	// Range is the visible document range for which hints were requested.
+	// Providers may use this to skip work outside the visible area.
+	Range   ts.Range
 	Publish InlayHintPublish
 }
 

--- a/provider/inlay_hint.go
+++ b/provider/inlay_hint.go
@@ -14,6 +14,7 @@ type InlayHintContext struct {
 	Publish InlayHintPublish
 }
 
+// Interface that providers that support inlay hints can implement.
 type InlayHintProvider interface {
 	ResolveInlayHints(InlayHintContext)
 }

--- a/provider/manager.go
+++ b/provider/manager.go
@@ -35,6 +35,7 @@ func (m *Manager) Init(ctx InitContext) {
 		ctx.Logger.WithError(err).Warn("failed to find binary")
 	}
 
+	ctx.Project = m.project
 	for _, provider := range m.providers {
 		provider.Init(ctx)
 	}
@@ -140,4 +141,29 @@ func (m *Manager) InlayHints(ctx InlayHintContext) {
 			provider.ResolveInlayHints(ctx)
 		}
 	}
+}
+
+// FileSaved notifies all providers of a file save. Returns a channel that
+// closes when all providers have finished re-warming their caches, or nil if
+// no provider was affected.
+func (m *Manager) FileSaved(filename string) <-chan struct{} {
+	var chans []<-chan struct{}
+	for _, provider := range m.providers {
+		if p, ok := provider.(FileSaveProvider); ok {
+			if ch := p.OnFileSaved(filename); ch != nil {
+				chans = append(chans, ch)
+			}
+		}
+	}
+	if len(chans) == 0 {
+		return nil
+	}
+	done := make(chan struct{})
+	go func() {
+		for _, ch := range chans {
+			<-ch
+		}
+		close(done)
+	}()
+	return done
 }

--- a/provider/manager.go
+++ b/provider/manager.go
@@ -11,6 +11,7 @@ type Language struct {
 	DefinitionProviders  []DefinitionProvider
 	CodeActionProviders  []CodeActionProvider
 	HoverProviders       []HoverProvider
+	InlayHintProviders   []InlayHintProvider
 }
 
 type Manager struct {
@@ -55,6 +56,7 @@ func (m *Manager) Register(typ file.Type, provider any) {
 			DiagnosticsProviders: []DiagnosticProvider{},
 			DefinitionProviders:  []DefinitionProvider{},
 			HoverProviders:       []HoverProvider{},
+			InlayHintProviders:   []InlayHintProvider{},
 		}
 		lang = m.languages[typ]
 	}
@@ -77,6 +79,10 @@ func (m *Manager) Register(typ file.Type, provider any) {
 
 	if codeAction, ok := provider.(CodeActionProvider); ok {
 		lang.CodeActionProviders = append(lang.CodeActionProviders, codeAction)
+	}
+
+	if inlayHint, ok := provider.(InlayHintProvider); ok {
+		lang.InlayHintProviders = append(lang.InlayHintProviders, inlayHint)
 	}
 
 	m.languages[typ] = lang
@@ -123,6 +129,15 @@ func (m *Manager) Hover(ctx HoverContext) {
 	if providers, ok := m.languages[ctx.File.Type]; ok {
 		for _, provider := range providers.HoverProviders {
 			provider.Hover(ctx)
+		}
+	}
+}
+
+func (m *Manager) InlayHints(ctx InlayHintContext) {
+	ctx.Project = m.project
+	if providers, ok := m.languages[ctx.File.Type]; ok {
+		for _, provider := range providers.InlayHintProviders {
+			provider.ResolveInlayHints(ctx)
 		}
 	}
 }

--- a/provider/manager.go
+++ b/provider/manager.go
@@ -56,6 +56,7 @@ func (m *Manager) Register(typ file.Type, provider any) {
 			CompletionProviders:  []CompletionProvider{},
 			DiagnosticsProviders: []DiagnosticProvider{},
 			DefinitionProviders:  []DefinitionProvider{},
+			CodeActionProviders:  []CodeActionProvider{},
 			HoverProviders:       []HoverProvider{},
 			InlayHintProviders:   []InlayHintProvider{},
 		}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"github.com/laravel-ls/laravel-ls/cache"
+	"github.com/laravel-ls/laravel-ls/project"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -10,6 +11,7 @@ type InitContext struct {
 	Logger    *log.Entry
 	RootPath  string
 	FileCache *cache.FileCache
+	Project   *project.Project
 }
 
 type Provider interface {


### PR DESCRIPTION
Displays the method and URI of matching routes as inlay hints on controller methods. For example, a HomeController::index method that handles GET / will show [GET /] inline at the method declaration.

Changes:
- Inlay hint support
- Route provider implements ResolveInlayHints by parsing the controller file's namespace, class name, and method positions via Tree-sitter, then matching against the route list by FQN or unqualified class name. 
- Introduces an in-memory route cache with generation based invalidation on routes-directory file saves.
- LSP server handles textDocument/inlayHint requests. 
- Adds LSPConfig parsed from initializationOptions, allowing clients to disable route inlay hints via inlayHints.routes.enabled = false.
- Adds a basic Nix flake dev shell providing dependencies. Doesn't cover any build steps.