### PR TITLE
Add support for ".tinker" files

### DIFF
--- a/file/type.go
+++ b/file/type.go
@@ -12,6 +12,7 @@ const (
 	TypePHP
 	TypeBlade
 	TypeEnv
+	TypeTinker
 )
 
 // TypeByFilename finds the filetype based on filename
@@ -24,9 +25,14 @@ func TypeByFilename(filename string) Type {
 		return TypePHP
 	}
 
+	if strings.HasSuffix(filename, ".tinker") {
+		return TypeTinker
+	}
+
 	filename = path.Base(filename)
 	if filename == ".env" || strings.HasPrefix(filename, ".env.") {
 		return TypeEnv
+
 	}
 
 	return TypeUnknown

--- a/file/type.go
+++ b/file/type.go
@@ -32,7 +32,6 @@ func TypeByFilename(filename string) Type {
 	filename = path.Base(filename)
 	if filename == ".env" || strings.HasPrefix(filename, ".env.") {
 		return TypeEnv
-
 	}
 
 	return TypeUnknown

--- a/file/type_test.go
+++ b/file/type_test.go
@@ -23,6 +23,11 @@ func Test_TypeByFilename(t *testing.T) {
 			expected: file.TypePHP,
 		},
 		{
+			name:     "Tinker",
+			filename: "/path/to/file.tinker",
+			expected: file.TypeTinker,
+		},
+		{
 			name:     "Env",
 			filename: "/path/to/.env",
 			expected: file.TypeEnv,

--- a/laravel/providers/app/provider.go
+++ b/laravel/providers/app/provider.go
@@ -25,6 +25,7 @@ func (p *Provider) Init(ctx provider.InitContext) {
 func (p *Provider) Register(manager *provider.Manager) {
 	manager.Register(file.TypePHP, p)
 	manager.Register(file.TypeBlade, p)
+	manager.Register(file.TypeTinker, p)
 }
 
 func (p *Provider) Hover(ctx provider.HoverContext) {

--- a/laravel/providers/assets/provider.go
+++ b/laravel/providers/assets/provider.go
@@ -25,6 +25,7 @@ func NewProvider() *Provider {
 func (p *Provider) Register(manager *provider.Manager) {
 	manager.Register(file.TypePHP, p)
 	manager.Register(file.TypeBlade, p)
+	manager.Register(file.TypeTinker, p)
 }
 
 func (p *Provider) Init(ctx provider.InitContext) {

--- a/laravel/providers/config/provider.go
+++ b/laravel/providers/config/provider.go
@@ -26,6 +26,7 @@ func (p *Provider) Init(ctx provider.InitContext) {
 func (p *Provider) Register(manager *provider.Manager) {
 	manager.Register(file.TypePHP, p)
 	manager.Register(file.TypeBlade, p)
+	manager.Register(file.TypeTinker, p)
 }
 
 func (p *Provider) Hover(ctx provider.HoverContext) {

--- a/laravel/providers/env/provider.go
+++ b/laravel/providers/env/provider.go
@@ -31,6 +31,7 @@ func NewProvider() *Provider {
 func (p *Provider) Register(manager *provider.Manager) {
 	manager.Register(file.TypePHP, p)
 	manager.Register(file.TypeBlade, p)
+	manager.Register(file.TypeTinker, p)
 }
 
 func (p *Provider) Init(ctx provider.InitContext) {

--- a/laravel/providers/route/provider.go
+++ b/laravel/providers/route/provider.go
@@ -21,6 +21,7 @@ func NewProvider() *Provider {
 
 func (p *Provider) Register(manager *provider.Manager) {
 	manager.Register(file.TypePHP, p)
+	manager.Register(file.TypeTinker, p)
 }
 
 func (p *Provider) Init(ctx provider.InitContext) {

--- a/laravel/providers/view/provider.go
+++ b/laravel/providers/view/provider.go
@@ -33,6 +33,7 @@ func (p *Provider) Init(ctx provider.InitContext) {
 func (p *Provider) Register(manager *provider.Manager) {
 	manager.Register(file.TypePHP, p)
 	manager.Register(file.TypeBlade, p)
+	manager.Register(file.TypeTinker, p)
 }
 
 // resolve view() calls to view files.

--- a/treesitter/language/registry.go
+++ b/treesitter/language/registry.go
@@ -41,6 +41,8 @@ func FiletypeToLanguage(t file.Type) Identifier {
 	switch t {
 	case file.TypePHP:
 		return PHP
+	case file.TypeTinker:
+		return PHP
 	case file.TypeBlade:
 		return Blade
 	case file.TypeEnv:


### PR DESCRIPTION
It's pretty common to have ".tinker" files on Laravel projects, that should be interpreted as PHP scripts.

Similar to what Tinkerwell application does. Or other plugins that let you run these scripts directly against your project (usually passing it's content to `php artisan tinker --execute "<php code>"`.

This PR adds detection for such files, with extension ".tinker".
It recognizes them as PHP files (for treesitter parsing).
And registers the providers to work on Tinker files.